### PR TITLE
fix(imports): Use cordova-support-google-services

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -65,10 +65,13 @@
 				</feature>
 		</config-file>
 		
-        <framework src="com.google.firebase:firebase-core:+" />
-        <framework src="com.google.firebase:firebase-messaging:+" />
+	        <dependency id="cordova-support-android-plugin" version="~1.0.0"/>
+		<dependency id="cordova-support-google-services" version="~1.2.0"/>
+	    
+        	<framework src="com.google.firebase:firebase-core:+" />
+       		<framework src="com.google.firebase:firebase-messaging:+" />
 		
-		<framework src="src/android/FCMPlugin.gradle" custom="true" type="gradleReference"/>
+		<!--<framework src="src/android/FCMPlugin.gradle" custom="true" type="gradleReference"/>-->
 			
 		<source-file src="src/android/FCMPlugin.java" target-dir="src/com/gae/scaffolder/plugin" />
 		<source-file src="src/android/MyFirebaseMessagingService.java" target-dir="src/com/gae/scaffolder/plugin" />


### PR DESCRIPTION
Use cordova-support-google-services to import the google services instead of doing it manually.
This ensures that it is only imported once when using with other plugins that rely on this dependency.
Required by https://github.com/RADAR-base/RADAR-Questionnaire/pull/272